### PR TITLE
Set white background for app readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Original Torrent is a browser-only torrent streamer for music creators and liste
 - **Minimal UI** – plain HTML + JS, no build step or framework.
 - **Runtime config** – trackers and ICE servers are stored in `config.json` for easy updates.
 - **Logging & stats** – live peer count, speed, and progress display.
+- **Light background** – explicitly sets a white background for consistent readability.
 
 ## Getting Started
 1. Clone the repository.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <style>
     :root { --gap:12px; }
     * { box-sizing: border-box; }
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 16px; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 16px; background: #fff; color: #000; }
     h1 { margin: 0 0 8px; }
     .card { border:1px solid #e5e5e5; border-radius:12px; padding:16px; margin-bottom:16px; }
     .row { display:grid; gap: var(--gap); grid-template-columns: 1fr auto; align-items:center; }


### PR DESCRIPTION
## Summary
- Explicitly set a white background and black text color for the app to prevent dark-mode rendering issues.
- Document the light background in the README features list.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5257d018832a9624113fcba900fe