### PR TITLE
fix: update miniapp sdk import source

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 
   <!-- Farcaster MiniApp SDK -->
   <script type="module">
-    import { sdk } from "https://miniapps.farcaster.xyz/sdk";
+    import { sdk } from "https://esm.sh/@farcaster/miniapp-sdk";
     addEventListener("DOMContentLoaded", () => {
       try { sdk.actions.ready(); } catch {}
     });


### PR DESCRIPTION
## Summary
- use esm.sh host for Farcaster MiniApp SDK import

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba56c6a820832a977835952f2cf43c