### PR TITLE
Respect magnet-provided trackers when streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Original Torrent is a browser-only torrent streamer for music creators and liste
 - **Farcaster MiniApp ready** – includes `/.well-known/farcaster.json` manifest and frame tags.
 - **WebRTC + WebTorrent** – pure browser streaming over WebSocket trackers (no TCP/UDP, no server).
 - **Listener mode** – paste a magnet URI to stream audio into a native `<audio>` player.
+- **Combined trackers** – merges trackers from the magnet URI with those in `config.json` to improve peer discovery.
 - **Creator mode** – select a local audio file, generate a magnet link, copy it, and seed directly from the browser.
 - **Minimal UI** – plain HTML + JS, no build step or framework.
 - **Runtime config** – trackers and ICE servers are stored in `config.json` for easy updates.

--- a/index.html
+++ b/index.html
@@ -146,8 +146,14 @@
 
       statusEl.textContent = "Connecting…";
       log("Adding torrent: " + magnetURI);
+      let announce = conf.trackers || [];
+      try {
+        const url = new URL(magnetURI);
+        const tr = url.searchParams.getAll('tr');
+        announce = Array.from(new Set([...announce, ...tr]));
+      } catch {}
 
-      const torrent = c.add(magnetURI, { announce: conf.trackers || [] });
+      const torrent = c.add(magnetURI, { announce });
       activeTorrent = torrent;
       hookTorrentEvents(torrent);
 


### PR DESCRIPTION
## Summary
- Merge trackers from incoming magnet URIs with those from `config.json`
- Document tracker merging behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5dd9d04c832a9cd6c80b69ffede4