### PR TITLE
Load seeding trackers and ICE servers from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Original Torrent is a browser-only torrent streamer for music creators and liste
 No installation or build step is required. The app seeds or streams audio directly from the browser.
 
 ## Configuration
-Edit `config.json` to change the list of WebTorrent trackers, WebRTC ICE servers, or the number of bytes to prefetch before playback. Seeding uses a built-in tracker list in `index.html`.
+Edit `config.json` to change the list of WebTorrent trackers, WebRTC ICE servers, or the number of bytes to prefetch before playback. Both listening and seeding use these values.
 
 ## Development
 This project intentionally avoids build tools and external dependencies. Keep contributions self-contained and minimal. Run `npm test` if test scripts are added in the future.

--- a/index.html
+++ b/index.html
@@ -198,12 +198,24 @@
   <script type="module">
     import WebTorrent from "https://esm.sh/webtorrent@2.3.0";
 
-    const TRACKERS = [
-      "wss://tracker.openwebtorrent.com",
-      "wss://tracker.btorrent.xyz",
-      "wss://tracker.webtorrent.dev"
-    ];
-    const ICE_SERVERS = [{ urls: "stun:stun.l.google.com:19302" }];
+    let cfg, client;
+
+    async function loadConfig() {
+      if (cfg) return cfg;
+      const res = await fetch("./config.json", { cache: "no-store" });
+      cfg = await res.json();
+      return cfg;
+    }
+
+    async function ensureClient() {
+      if (client) return client;
+      const conf = await loadConfig();
+      client = new WebTorrent({
+        tracker: { rtcConfig: { iceServers: conf.iceServers || [] } }
+      });
+      client.on("error", (e) => setStatus("Client error: " + (e?.message || e)));
+      return client;
+    }
 
     const fileInput  = document.getElementById("fileInput");
     const seedBtn    = document.getElementById("seedBtn");
@@ -211,11 +223,6 @@
     const magnetRow  = document.getElementById("magnetRow");
     const magnetOut  = document.getElementById("magnetOut");
     const copyBtn    = document.getElementById("copyBtn");
-
-    const client = new WebTorrent({
-      tracker: { rtcConfig: { iceServers: ICE_SERVERS } }
-    });
-    client.on("error", (e) => setStatus("Client error: " + (e?.message || e)));
 
     function setStatus(msg) {
       seedStatus.textContent = msg;
@@ -225,7 +232,9 @@
       seedBtn.disabled = true;
       setStatus("Preparing…");
 
-      client.seed(file, { announce: TRACKERS }, (torrent) => {
+      const conf = await loadConfig();
+      const c = await ensureClient();
+      c.seed(file, { announce: conf.trackers || [] }, (torrent) => {
         setStatus(`Seeding "${torrent.name}" — keep this tab open to serve peers.`);
         magnetOut.value = torrent.magnetURI;
         magnetRow.style.display = "block";


### PR DESCRIPTION
## Summary
- load config.json inside seeding module
- use config trackers and iceServers for WebTorrent and seeding
- document that config.json drives both listening and seeding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f3a59a0832aa3dcd565c82b7a6d