### PR TITLE
Handle config load errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Original Torrent is a browser-only torrent streamer for music creators and liste
 - **Creator mode** – select a local audio file, generate a magnet link, copy it, and seed directly from the browser.
 - **Minimal UI** – plain HTML + JS, no build step or framework.
 - **Runtime config** – trackers and ICE servers are stored in `config.json` for easy updates.
+- **Graceful config errors** – displays a message if `config.json` fails to load or parse.
 - **Logging & stats** – live peer count, speed, and progress display.
 - **Light background** – explicitly sets a white background for consistent readability.
 

--- a/index.html
+++ b/index.html
@@ -107,8 +107,19 @@
 
     async function loadConfig() {
       if (cfg) return cfg;
-      const res = await fetch("./config.json", { cache: "no-store" });
-      cfg = await res.json();
+      try {
+        const res = await fetch("./config.json", { cache: "no-store" });
+        if (!res.ok) {
+          throw new Error(res.statusText || ("HTTP " + res.status));
+        }
+        cfg = await res.json();
+      } catch (e) {
+        const msg = "Failed to load config.";
+        statusEl.textContent = msg;
+        setStatus(msg);
+        log(msg + " " + (e?.message || e));
+        throw e;
+      }
       return cfg;
     }
 


### PR DESCRIPTION
## Summary
- surface config.json load failures to users
- document new config error handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba812ce464832a8376f417448ae1dd