### PR TITLE
Expose network and bandwidth config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Original Torrent is a browser-only torrent streamer for music creators and liste
 No installation or build step is required. The app seeds or streams audio directly from the browser.
 
 ## Configuration
-Edit `config.json` to change the list of WebTorrent trackers, WebRTC ICE servers, or the number of bytes to prefetch before playback. Both listening and seeding use these values.
+Edit `config.json` to change the list of WebTorrent trackers, WebRTC ICE servers, or the number of bytes to prefetch before playback. Both listening and seeding use these values. Advanced fields like `maxConns`, `strategy`, `dht`, `lsd`, `webSeeds`, `uploadLimit`, `downloadLimit`, and `blocklist` can also be tweaked for connectivity and bandwidth control.
 
 ## Development
 This project intentionally avoids build tools and external dependencies. Keep contributions self-contained and minimal. Run `npm test` if test scripts are added in the future.

--- a/index.html
+++ b/index.html
@@ -127,7 +127,14 @@
       if (client) return client;
       const conf = await loadConfig();
       client = new WebTorrent({
-        tracker: { rtcConfig: { iceServers: conf.iceServers || [] } }
+        tracker: { rtcConfig: { iceServers: conf.iceServers || [] } },
+        maxConns: conf.maxConns,
+        dht: conf.dht,
+        lsd: conf.lsd,
+        webSeeds: conf.webSeeds,
+        uploadLimit: conf.uploadLimit,
+        downloadLimit: conf.downloadLimit,
+        blocklist: conf.blocklist
       });
       client.on("error", (e) => {
         const msg = "Client error: " + (e?.message || e);
@@ -182,7 +189,7 @@
         announce = Array.from(new Set([...announce, ...tr]));
       } catch {}
 
-      const torrent = c.add(magnetURI, { announce });
+      const torrent = c.add(magnetURI, { announce, strategy: conf.strategy });
       activeTorrent = torrent;
       hookTorrentEvents(torrent);
 
@@ -220,7 +227,7 @@
       const conf = await loadConfig();
       let torrent;
       try {
-        torrent = c.seed(file, { announce: conf.trackers || [] }, (t) => {
+        torrent = c.seed(file, { announce: conf.trackers || [], strategy: conf.strategy }, (t) => {
           setStatus(`Seeding "${t.name}" — keep this tab open to serve peers.`);
           magnetOut.value = t.magnetURI;
           magnetRow.style.display = "block";


### PR DESCRIPTION
## Summary
- pass runtime config flags to WebTorrent constructor (maxConns, dht, lsd, webSeeds, upload/download limits, blocklist)
- include strategy option when adding or seeding torrents
- document advanced config fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba81dbcb10832a82da1928daebc362