### PR TITLE
Load WebTorrent from CDN and use global class

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,10 +72,11 @@
     });
   </script>
 
-  <!-- WebTorrent (browser ESM) + app logic -->
-  <script type="module">
-    import WebTorrent from "https://esm.sh/webtorrent@2.3.0";
+  <!-- WebTorrent library -->
+  <script src="https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js"></script>
 
+  <!-- App logic -->
+  <script>
     // UI
     const logEl = document.getElementById('log');
     const statusEl = document.getElementById('status');


### PR DESCRIPTION
## Summary
- replace ESM WebTorrent import with CDN script tag
- move app logic into a non-module script using the global `WebTorrent`

## Testing
- ⚠️ `npm test` (no package.json)
- ⚠️ `xdg-open index.html` (command not found in container)
- ✅ `curl -I file://$(pwd)/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68ba885bcc20832a82135f07b74ecc9f