### PR TITLE
Sanitize magnet links to WebSocket trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Original Torrent is a browser-only torrent streamer for music creators and liste
 - **Farcaster MiniApp ready** – includes `/.well-known/farcaster.json` manifest and frame tags.
 - **WebRTC + WebTorrent** – pure browser streaming over WebSocket trackers (no TCP/UDP, no server).
 - **Listener mode** – paste a magnet URI to stream audio into a native `<audio>` player.
-- **Combined trackers** – merges WebSocket trackers from the magnet URI with those in `config.json` and ignores unsupported protocols.
+- **Combined trackers** – merges WebSocket trackers from the magnet URI with those in `config.json` and strips unsupported protocols from the magnet before use.
 - **Creator mode** – select a local audio file, generate a magnet link, copy it, and seed directly from the browser.
 - **Minimal UI** – plain HTML + JS, no build step or framework.
 - **Runtime config** – trackers and ICE servers are stored in `config.json` for easy updates.

--- a/index.html
+++ b/index.html
@@ -201,17 +201,29 @@
       }
 
       statusEl.textContent = "Connecting…";
-      log("Adding torrent: " + magnetURI);
       let announce = conf.trackers || [];
+      let sanitized = magnetURI;
       try {
         const url = new URL(magnetURI);
-        const tr = url.searchParams.getAll('tr');
-        announce = Array.from(new Set([...announce, ...tr]));
+        const params = url.searchParams;
+        const tr = params.getAll('tr');
+        const keep = [];
+        const removed = [];
+        tr.forEach(t => {
+          if (/^wss?:\/\//.test(t)) keep.push(t);
+          else removed.push(t);
+        });
+        params.delete('tr');
+        keep.forEach(t => params.append('tr', t));
+        if (removed.length) log("Removed trackers from magnet: " + removed.join(", "));
+        sanitized = url.toString();
+        announce = Array.from(new Set([...announce, ...keep]));
       } catch {}
 
       announce = filterTrackers(announce);
+      log("Adding torrent: " + sanitized);
 
-      const torrent = c.add(magnetURI, { announce, strategy: 'sequential' });
+      const torrent = c.add(sanitized, { announce, strategy: 'sequential' });
       activeTorrent = torrent;
       hookTorrentEvents(torrent);
 


### PR DESCRIPTION
## Summary
- sanitize magnet URIs so only `ws`/`wss` trackers remain before adding torrents
- document tracker sanitization in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa7de8030832a93d0b51a8190f130