### PR TITLE
chore: refresh tracker list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Edit `config.json` to control connectivity and playback behavior. Both listening
 ### Options
 - `iceServers`: WebRTC STUN/TURN servers. The default TURN entries use the public [OpenRelay](https://www.metered.ca/tools/openrelay/) service with `openrelayproject` credentials for testing. For production, obtain your own `username` and `credential` from a TURN provider.
 - `trackers`: WebSocket trackers used for peer discovery.
+  Defaults include `wss://tracker.openwebtorrent.com`,
+  `wss://tracker.btorrent.xyz`,
+  `wss://tracker.ghostchu-services.top/announce`, and
+  `wss://tracker.files.fm:7073/announce`. Monitor these periodically and
+  replace any that stop responding.
 - `prerollBytes`: Number of bytes to fetch before playback begins.
 - `maxConns`: Maximum number of simultaneous peer connections.
 - `strategy`: Piece download strategy for seeding (`sequential` streams from start; playback always uses sequential).

--- a/config.json
+++ b/config.json
@@ -20,8 +20,8 @@
   "trackers": [
     "wss://tracker.openwebtorrent.com",
     "wss://tracker.btorrent.xyz",
-    "wss://tracker.fastcast.nz",
-    "wss://tracker.webtorrent.dev"
+    "wss://tracker.ghostchu-services.top/announce",
+    "wss://tracker.files.fm:7073/announce"
   ],
   "prerollBytes": 2097152,
   "maxConns": 100,


### PR DESCRIPTION
## Summary
- remove dead trackers from `config.json`
- add active websocket trackers and document them in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa945de7c832a846e7569faf1ed8e